### PR TITLE
Move server to runner. Launch it only once.

### DIFF
--- a/scripts/bench/benchmark.js
+++ b/scripts/bench/benchmark.js
@@ -2,7 +2,6 @@
 
 const Lighthouse = require('lighthouse');
 const ChromeLauncher = require('lighthouse/lighthouse-cli/chrome-launcher.js').ChromeLauncher;
-const serveBenchmark = require('./server');
 const stats = require('stats-analysis');
 const config = require('lighthouse/lighthouse-core/config/perf.json');
 const spawn = require('child_process').spawn;
@@ -15,7 +14,7 @@ function wait(val) {
 }
 
 async function runScenario(benchmark, launcher) {
-  const results = await Lighthouse(`http://localhost:8080/?${benchmark}`, {
+  const results = await Lighthouse(`http://localhost:8080/${benchmark}/`, {
     output: 'json',
   }, config);
   const perfMarkings = results.audits['user-timings'].extendedInfo.value;
@@ -81,12 +80,6 @@ async function launchChrome() {
 }
 
 async function runBenchmark(benchmark, startServer) {
-  let server;
-
-  if (startServer) {
-    server = serveBenchmark(benchmark);
-    await wait(1000);
-  }
 
   const results = {
     runs: [],
@@ -97,15 +90,13 @@ async function runBenchmark(benchmark, startServer) {
 
   for (let i = 0; i < timesToRun; i++) {
     let launcher = await launchChrome();
-    results.runs.push(await runScenario(benchmark, launcher));
 
+    results.runs.push(await runScenario(benchmark, launcher));
     // add a delay or sometimes it confuses lighthouse and it hangs
     await wait(500);
     await launcher.kill();
   }
-  if (startServer) {
-    server.close();
-  }
+
   results.averages = calculateAverages(results.runs);
   return results;
 }

--- a/scripts/bench/server.js
+++ b/scripts/bench/server.js
@@ -2,7 +2,7 @@
 
 const http2Server = require('http2');
 const httpServer = require('http-server');
-const { 
+const {
   existsSync,
   statSync,
   createReadStream,
@@ -45,11 +45,11 @@ function createHTTP2Server(benchmark) {
   return server;
 }
 
-function createHTTPServer(benchmark) {
+function createHTTPServer() {
   const server = httpServer.createServer({
-    root: join(__dirname, 'benchmarks', benchmark),
+    root: join(__dirname, 'benchmarks'),
     robots: true,
-    cache: 'no-cache',
+    cache: 'no-store',
     headers: {
       'Access-Control-Allow-Origin': '*',
       'Access-Control-Allow-Credentials': 'true',


### PR DESCRIPTION
I think the ultimate bug is that [`server.close()`](https://github.com/trueadm/react/blob/d076faafe955a2dc86691a256d315c1bd1697dbf/scripts/bench/benchmark.js#L112) wasn't closing the server.. so a subsequent request for localhost:8080 was continuing to provide the original files, since the [file `root`](https://github.com/trueadm/react/blob/d076faafe955a2dc86691a256d315c1bd1697dbf/scripts/bench/server.js#L50) for the server was set back then.

----

This is the fix that made sense for me... but there's a few ways to do this. No worries if you'd rather solve it differently :)

* Move createServer from launching once per benchmark to launching just once for everything
* Use direct paths to the benchmark folders rather than a query param. 
  * I didn't touch the http2 server, but AFAICT an adjustment is necessary there, as well.
* Whitespace cleanup (sorry)
* `no-store` rather than `no-cache` but really this shouldn't matter. This part is @patrickhulce's fault. ;)



This closes https://github.com/GoogleChrome/lighthouse/issues/2064

