### PR TITLE
Add compiler test fixture infra

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,6 +102,7 @@
     "lint": "node ./scripts/tasks/eslint.js",
     "postinstall": "node node_modules/fbjs-scripts/node/check-dev-engines.js package.json",
     "test": "jest",
+    "test:compiler": "jest Compiler-test",
     "flow": "node ./scripts/tasks/flow.js",
     "prettier": "node ./scripts/prettier/index.js write-changed",
     "prettier-all": "node ./scripts/prettier/index.js write",

--- a/scripts/compiler-fixtures/__tests__/Compiler-test.js
+++ b/scripts/compiler-fixtures/__tests__/Compiler-test.js
@@ -1,0 +1,54 @@
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @flow
+ */
+'use strict';
+
+const babel = require('babel-core');
+const fs = require('fs');
+const path = require('path');
+const React = require('ReactEntry');
+const ReactTestRenderer = require('ReactTestRendererFiberEntry');
+const transform = require('./transform');
+
+function runSource(code) {
+  const codeAfterBabel = babel.transform(code, {
+    presets: ['babel-preset-react'],
+    plugins: ['transform-object-rest-spread'],
+  }).code;
+  const fn = new Function('React', 'module', codeAfterBabel);
+  let module = {exports: null};
+  fn(React, module);
+  return module.exports;
+}
+
+function getOutput(Root) {
+  const renderer = ReactTestRenderer.create(<Root />);
+  // TODO: test updates, unmounting too
+  return renderer.toJSON();
+}
+
+async function runFixture(name) {
+  const src = fs.readFileSync(path.join(__dirname, name)).toString();
+  const transformed = await transform(src);
+
+  const After = runSource(transformed);
+  expect(typeof After).toBe('function');
+
+  const Before = runSource(src);
+  expect(typeof Before).toBe('function');
+
+  expect(getOutput(After)).toEqual(getOutput(Before));
+}
+
+describe('Compiler', () => {
+  it('does something', async () => {
+    await runFixture('fixtures/simple.js');
+  });
+});

--- a/scripts/compiler-fixtures/__tests__/fixtures/simple.js
+++ b/scripts/compiler-fixtures/__tests__/fixtures/simple.js
@@ -1,0 +1,28 @@
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+'use strict';
+
+function A() {
+  return <div>Hello</div>;
+}
+
+function B() {
+  return <div>World</div>;
+}
+
+function C() {
+  return (
+    <div>
+      <A />
+      <B />
+    </div>
+  );
+}
+
+module.exports = C;

--- a/scripts/compiler-fixtures/__tests__/transform.js
+++ b/scripts/compiler-fixtures/__tests__/transform.js
@@ -1,0 +1,19 @@
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @flow
+ */
+'use strict';
+
+module.exports = async function(src: string) {
+  // Put the real compilation call here
+  await Promise.resolve();
+  return src;
+  // Uncomment to see a failure:
+  // return src.replace('World', 'Dominic');
+};


### PR DESCRIPTION
This adds a basic fixture for the compiler.
To run: `yarn test:compiler` (unfortunately it will run everything twice but we can fix that later).

Fixtures are placed in a special directory. They look like this:

```js
function A() {
  return <div>Hello</div>;
}

function B() {
  return <div>World</div>;
}

function C() {
  return (
    <div>
      <A />
      <B />
    </div>
  );
}

module.exports = C;
```

They must export a component. We’ll probably use a different format later to account for updates but for now this will do.

A test looks like this:

```js
  it('does something', async () => {
    await runFixture('fixtures/simple.js');
  });
```

That’s about it.

The test runner calls `./transform.js` which is hardcoded to not do anything.

```js

module.exports = async function(src: string) {
  // Put the real compilation call here
  await Promise.resolve();
  return src;
  // Uncomment to see a failure:
  // return src.replace('World', 'Dominic');
};
```

This is where you’ll need to plug the compiler.

The test runner will pass compiled and uncompiled code through Babel, passing React as a global. Then will compare the tree rendered with test renderer. We might need to make it work with `findDOMNode` later but it’s not super important right now. We’ll also need some way to assert about the same console output and updates (top level and `setState`).

I’ll work on that and more sophisticated fixtures tomorrow.